### PR TITLE
Updates4

### DIFF
--- a/src/RingMatrices.jl
+++ b/src/RingMatrices.jl
@@ -75,6 +75,8 @@ function RingMatrix(p::T, n) where T <: Real
 end
 
 Base.size(X::RingMatrix{T}) where T <: Real = (X.n,X.n)
+Base.eachindex(X::RingMatrix{T}) where T <: Real = X.index
+entries(X::RingMatrix{T}) where T <: Real = X.entries
 
 function Base.getindex(X::RingMatrix{T}, ii::CartesianIndex) where T <: Real    
     if ii in CartesianIndices((1:X.n, 1:X.n))
@@ -116,6 +118,7 @@ end
 
 RingProductMatrix(f1::RingMatrix{T}, f2::RingMatrix{T}) where T <: Real = RingProductMatrix(f1,f2, f1.n*f2.n)
 Base.size(X::RingProductMatrix{T}) where T <: Real = (X.n, X.n)
+Base.eachindex(X::RingProductMatrix{T}) where T <: Real = X.index
 
 function Base.getindex(X::RingProductMatrix{T}, i::Integer, j::Integer) where T <: Real
     p1 = X.f1.p
@@ -261,7 +264,7 @@ function PairwiseCombinations(X::Vector{RingMatrix{T}}) where T <: Real
     PairwiseCombinations(p, prod(nn), nn[1], nstates, index, sindex, eindex, kstates, entries)
 end
 Base.size(X::PairwiseCombinations{T}) where T <: Real = (X.n, X.n)
-
+Base.eachindex(X::PairwiseCombinations{T}) where T <: Real = X.index
 """
 ```
 function update_p!(Qp::PairwiseCombinations{T}, p::Vector{T}) where T <: Real
@@ -302,6 +305,7 @@ end
 
 Base.getindex(X::PairwiseCombinations{T},i::Integer, j::Integer) where T <: Real = getindex(X, CartesianIndex(i,j))
 Base.getindex(X::PairwiseCombinations{T},i,j) where T <: Real = getindex(X,broadcast(CartesianIndex, i, permutedims(j)))
+entries(X::PairwiseCombinations{T}) where T <: Real = X.entries
 
 """
 ```

--- a/src/RingMatrices.jl
+++ b/src/RingMatrices.jl
@@ -118,7 +118,6 @@ end
 
 RingProductMatrix(f1::RingMatrix{T}, f2::RingMatrix{T}) where T <: Real = RingProductMatrix(f1,f2, f1.n*f2.n)
 Base.size(X::RingProductMatrix{T}) where T <: Real = (X.n, X.n)
-Base.eachindex(X::RingProductMatrix{T}) where T <: Real = X.index
 
 function Base.getindex(X::RingProductMatrix{T}, i::Integer, j::Integer) where T <: Real
     p1 = X.f1.p

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,13 @@ using Test
 @testset "LogProb" begin
     px = 0.3
     py = 0.3
+    ⊗(px,py) ≈ px*py
+    ⊕(px,py) ≈ px+py
+    ⨸(px,py) ≈ px/py
+
     x = LogProb(log(px))
     y = LogProb(log(py))
+    @test Float64(x) == x.v
     @test ⊗(x,y) == LogProb(log(px) + log(py))
     @test ⊕(x,y) == LogProb(log(px + py))
     @test ⨸(x,y) == LogProb(log(px/py))
@@ -20,6 +25,7 @@ using Test
     @test ⨸(x,y) == Prob(px/py)
     @test one(Prob{Float64}) == Prob(1.0)
     @test zero(Prob{Float64}) == Prob(0.0)
+    @test RingMatrices.x1m(x) == Prob(1.0-px)
 end
 
 @testset "Basic" begin
@@ -67,6 +73,8 @@ end
     @test QQ[13:16, 5:8] ≈ Q[4,2].*Q2
     @test QQ[13:16, 9:12] ≈ Q[4,3].*Q2
     @test QQ[13:16, 13:16] ≈ Q[4,4].*Q2
+
+    @test RingMatrices.entries(Q) == Q.entries
 end
 
 @testset "Combinations" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,10 @@ end
     @test Q[4,1] ≈ Q[4,2] ≈ Q[4,4] ≈ 0.0
 
     @test_throws BoundsError Q[5,1]
+    @test RingMatrices.entries(Q) ≈ Q.entries
+    @test eachindex(Q) == Q.index
+    A = randn(4,4)
+    @test RingMatrices.entries(A) ≈ A
 
     Q2 = RingMatrices.RingMatrix(0.9, 4)
 
@@ -82,6 +86,9 @@ end
     @test all(Qp.entries[Qp.eindex] .≈ 0.9*(1-.9)^2) # two silent, one active
     @test_throws BoundsError Qp[0,1]
     @test_throws BoundsError Qp[65,1]
+
+    @test RingMatrices.entries(Qp) ≈ Qp.entries
+    @test eachindex(Qp) == Qp.index
 
     Qm = RingMatrices.decompose(Qp)
     @test Qm == [Q1,Q2,Q3] 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,10 @@ using Test
     @test ⨸(x,y) == LogProb(log(px/py))
     @test one(LogProb{Float64}) == LogProb(0.0)
     @test zero(LogProb{Float64}) == LogProb(-Inf)
+    io = IOBuffer()
+    show(io, x)
+    sx = String(take!(io))
+    @test sx == string(log(px))
 
     x = Prob(px)
     y = Prob(py)
@@ -25,6 +29,10 @@ using Test
     @test ⨸(x,y) == Prob(px/py)
     @test one(Prob{Float64}) == Prob(1.0)
     @test zero(Prob{Float64}) == Prob(0.0)
+    show(io, x)
+    sx = String(take!(io))
+    @test sx == string(px)
+
     @test RingMatrices.x1m(x) == Prob(1.0-px)
 end
 


### PR DESCRIPTION
This addresses #4, facilitating dealing with `RingMatrices` and `PairwiseCombinations` of `RingMatrices` where the entries are in the log-domain. Also adds a generic `entries` function to get return the valid entries of the matrix. This, together with `eachindex` should make it easy and fast to iterate through the valid state. For convenience, `entries` is also defined for generic matrices, so that this syntax will work for all matrices

```julia
for (idx,ee) in zip(eachindex(A), entries(A))
    ...
end
```